### PR TITLE
Fix debian dependencies

### DIFF
--- a/build-tools/debian/control
+++ b/build-tools/debian/control
@@ -12,6 +12,6 @@ Vcs-Git: git@github.com:flickr-downloadr/flickr-downloadr-gtk.git
 Priority: optional
 Installed-Size: ${bitrock_deb_installedSize}
 Version: ${bitrock_deb_version}
-Depends : mono-complete, gtk-sharp3
+Depends: mono-runtime (>=3.12), ca-certificates-mono, libmono-system-web-extensions4.0-cil, libmono-microsoft-csharp4.0-cil, gtk-sharp2
 
 


### PR DESCRIPTION
Mono version set to >=3.12 due ca-certificates-mono changes.
gkt-sharp set to Gtk-Sharp2
Reduced number of Mono dependencies