### PR TITLE
Fixed issue #53 - corrupted images in cache

### DIFF
--- a/source/FloydPink.Flickr.Downloadr.UI/CachedImage/FileCache.cs
+++ b/source/FloydPink.Flickr.Downloadr.UI/CachedImage/FileCache.cs
@@ -30,7 +30,7 @@ namespace FloydPink.Flickr.Downloadr.UI.CachedImage
 
       // Cast the string into a Uri so we can access the image name without regex
       var uri = new Uri(url);
-      var localFile = string.Format("{0}/{1}", AppCacheDirectory, uri.Segments[uri.Segments.Length - 1]);
+      string localFile = GetLocalFilename(uri);
 
       if (!File.Exists(localFile))
       {
@@ -39,6 +39,11 @@ namespace FloydPink.Flickr.Downloadr.UI.CachedImage
 
       // The full path of the image on the local computer
       return localFile;
+    }
+
+    public static string GetLocalFilename(Uri uri)
+    {
+      return string.Format("{0}/{1}", AppCacheDirectory, uri.Segments[uri.Segments.Length - 1]);
     }
   }
 }

--- a/source/FloydPink.Flickr.Downloadr.UI/CachedImage/ImageExtension.cs
+++ b/source/FloydPink.Flickr.Downloadr.UI/CachedImage/ImageExtension.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using Gdk;
 using Image = Gtk.Image;
 
@@ -8,9 +9,48 @@ namespace FloydPink.Flickr.Downloadr.UI.CachedImage
   {
     public static void SetCachedImage(this Image self, string imageUrl)
     {
-      using (var file = new FileStream(FileCache.FromUrl(imageUrl), FileMode.Open))
+
+      int maxRetries = 2;
+      bool loaded = false;
+
+      for (int count = 1; !loaded; count++)
       {
-        self.Pixbuf = new Pixbuf(file);
+        using (var file = new FileStream(FileCache.FromUrl(imageUrl), FileMode.Open))
+        {
+          try
+          {
+            self.Pixbuf = new Pixbuf(file);
+            loaded = true;
+          }
+          catch (Exception e)
+          {
+
+            //possible corruption in a cached file, for example an partial aborted file.
+
+            if (count == maxRetries)
+            {
+              throw e;
+
+            }
+            else
+            {
+              file.Close();
+              HandeException(imageUrl, e);
+            }
+          }
+        }
+
+
+      }
+    }
+
+    private static void HandeException(string imageUrl, Exception e)
+    {
+      string corruptedFilename = FileCache.GetLocalFilename(new Uri(imageUrl));
+
+      if (File.Exists(corruptedFilename))
+      {
+        File.Delete(corruptedFilename);
       }
     }
   }


### PR DESCRIPTION
Now we try to recover in case of possible corrupted images, by deleting them and retrying a new read.
EDIT: see my PR on fix53bis.